### PR TITLE
Add config

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,8 @@ spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+spring.mvc.hiddenmethod.filter.enabled=true
+
 spring.web.resources.cache.cachecontrol.max-age=2592000
 spring.web.resources.cache.cachecontrol.cache-public=true
 

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -15,6 +15,8 @@ spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+spring.mvc.hiddenmethod.filter.enabled=true
+
 spring.web.resources.cache.cachecontrol.max-age=2592000
 spring.web.resources.cache.cachecontrol.cache-public=true
 


### PR DESCRIPTION
https://iikanji.hatenablog.jp/entry/2020/10/09/235515

> HTMLから送られた_methodというhiddenパラメータを含むPOSTリク[エス](http://d.hatena.ne.jp/keyword/%A5%A8%A5%B9)トを、このDELETE用のハンドラに変換する処理を行うHiddenHttpMethodFilterを有効化します。 Spring Boot 2.2系からはHiddenHttpMethodFilterがデフォルトで無効になっているので、設定ファイルに以下を追加します。
>
> ```
> spring.mvc.hiddenmethod.filter.enabled=true
> ```